### PR TITLE
cli runs as root user, plugins go missing

### DIFF
--- a/bin/contena
+++ b/bin/contena
@@ -8,7 +8,7 @@ docker volume create --name contena_home > /dev/null
 docker run -it --rm \
   --network host \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v contena_home:/home/kontena \
+  -v contena_home:/root \
   -v $(pwd):/host \
   -w /host \
   kontena/cli:$VERSION $@


### PR DESCRIPTION
Kontena CLI image runs as root user, I think the intent of mounting /home/kontena is to capture .kontena folder with gems etc.  Not sure if this is a change to the image but changing the contena_home volume to mount to at /root seems to fix it.  Thanks for the effort of putting this together, my biggest gripe about kontena is "great first I have to get the correct version of ruby installed..." and you've solved it neatly!